### PR TITLE
Include request body as string in hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,12 @@ function md5(str) {
 }
 
 async function getResponse(cacheDirPath, requestArguments, bodyFunctionName) {
-  const cacheHash = md5(JSON.stringify(requestArguments) + bodyFunctionName);
+  const [url, requestInit, ...rest] = requestArguments;
+  const requestParams = requestInit.body
+    ? Object.assign({}, requestInit, {body: typeof requestInit.body === 'object' ? requestInit.body.toString() : requestInit.body})
+    : requestInit;
+
+  const cacheHash = md5(JSON.stringify([url, requestParams, ...rest]) + bodyFunctionName);
   const cachedFilePath = path.join(cacheDirPath, `${cacheHash}.json`);
 
   try {


### PR DESCRIPTION
Doing a POST with `URLSearchParams` as body, I noticed I got the same data back for all requests. Turned out that the `JSON.stringify( )` just skips the body all together. 

I solved this by checking if the body property is an object, and if so, I use the toString( ) representation as input to the hash-function. Either this will return the default `[object object]` representation, which is neither better nor worse than current behavior, or it will return  a better representation like in the case of `URLSearchParams`. 