### PR TITLE
Stop testing on Node v16, start testing on Node v21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x, 21.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Since Node v16 has gone EOL and Node v21 has been released.