### PR TITLE
Unpin node-fetch: 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "cacache": "^18.0.4",
     "formdata-node": "^6.0.3",
     "locko": "^1.1.0",
-    "node-fetch": "3.3.2"
+    "node-fetch": "^3.3.2"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Libraries should not pin to specific versions in dependencies, but rather specify the minimum version they require, as those pins will propagate to packages using the library.